### PR TITLE
Enhancement/2023 01 enable generation of string paths from endpoint

### DIFF
--- a/modules/lepus-router/src/main/scala/lepus/router/DecodeEndpoint.scala
+++ b/modules/lepus-router/src/main/scala/lepus/router/DecodeEndpoint.scala
@@ -23,7 +23,7 @@ private[lepus] object DecodeEndpoint:
     val endpoints = endpoint.asVector()
 
     val endpointPaths       = endpoints.filter(_.isPath)
-    val endpointQueryParams = endpoints.filter(_.isQueryParam)
+    val endpointQueryParams = endpoints.filter(_.isQuery)
 
     decodingConvolution(
       tailrecMatchPath(DecodePathRequest(request), endpointPaths, _, _),

--- a/modules/lepus-router/src/main/scala/lepus/router/internal/ExtensionMethods.scala
+++ b/modules/lepus-router/src/main/scala/lepus/router/internal/ExtensionMethods.scala
@@ -8,36 +8,6 @@ import lepus.router.http.*
 
 trait ExtensionMethods extends lepus.core.internal.ExtensionMethods:
 
-  extension (endpoint: Endpoint[?])
-    def recursiveEndpoints[T](pf: PartialFunction[Endpoint[?], Vector[T]]): Vector[T] =
-      endpoint match
-        case Endpoint.Pair(left, right)          => left.recursiveEndpoints(pf) ++ right.recursiveEndpoints(pf)
-        case r: Endpoint[?] if pf.isDefinedAt(r) => pf(r)
-        case _                                   => Vector.empty
-
-    def asVector(): Vector[Endpoint[?]] =
-      recursiveEndpoints {
-        case e: Endpoint[?] => Vector(e)
-      }
-
-    def toPath: String = "/" + asVector()
-      .map {
-        case e: Endpoint.FixedPath[?] => e.name
-        case e: Endpoint.Path[?]      => s"{${ e.name }}"
-        case _                        => ""
-      }
-      .mkString("/")
-
-    def isPath: Boolean =
-      endpoint match
-        case _: Endpoint.Path[?] => true
-        case _                   => false
-
-    def isQueryParam: Boolean =
-      endpoint match
-        case _: Endpoint.Query[?] => true
-        case _                    => false
-
   // see https://github.com/scala/bug/issues/12186
   extension [T](v: Vector[T])
     def headAndTail: Option[(T, Vector[T])] = if v.isEmpty then None else Some((v.head, v.tail))

--- a/modules/lepus-router/src/test/scala/lepus/router/http/EndpointTest.scala
+++ b/modules/lepus-router/src/test/scala/lepus/router/http/EndpointTest.scala
@@ -6,6 +6,9 @@ package lepus.router.http
 
 import org.scalatest.flatspec.AnyFlatSpec
 
+import lepus.router.{ *, given }
+import lepus.router.http.Endpoint.*
+
 class EndpointTest extends AnyFlatSpec:
 
   it should "generate endpoint" in {
@@ -54,4 +57,19 @@ class EndpointTest extends AnyFlatSpec:
         case GET => Ok("Hello")
       }
     """.stripMargin)
+  }
+
+  it should "The Endpoint string will be the same as the specified string." in {
+    val endpoint1: Endpoint[String] = "test1" / bindPath[String]("p1")
+    endpoint1.formatString === "test1/%s"
+  }
+
+  it should "" in {
+    val endpoint1: Endpoint[String] = "test1" / bindPath[String]("p1")
+    val endpoint2: Endpoint[String] = bindPath[String]("p1") / "test2"
+    val endpoint3: Endpoint[(String, String)] = endpoint1 ++ endpoint2
+
+    println(endpoint3.toString.format("hello", "world"))
+
+    endpoint3.formatString === "test1/%s/%s/test2"
   }

--- a/modules/lepus-router/src/test/scala/lepus/router/http/EndpointTest.scala
+++ b/modules/lepus-router/src/test/scala/lepus/router/http/EndpointTest.scala
@@ -64,12 +64,23 @@ class EndpointTest extends AnyFlatSpec:
     endpoint1.formatString === "test1/%s"
   }
 
-  it should "" in {
-    val endpoint1: Endpoint[String] = "test1" / bindPath[String]("p1")
-    val endpoint2: Endpoint[String] = bindPath[String]("p1") / "test2"
+  it should "If multiple Endpoints are combined, the string will be the same as the specified value." in {
+    val endpoint1: Endpoint[String]           = "test1" / bindPath[String]("p1")
+    val endpoint2: Endpoint[String]           = bindPath[String]("p1") / "test2"
     val endpoint3: Endpoint[(String, String)] = endpoint1 ++ endpoint2
 
-    println(endpoint3.toString.format("hello", "world"))
-
     endpoint3.formatString === "test1/%s/%s/test2"
+  }
+
+  it should "Matches the string specified when the path is generated from Endpoint." in {
+    val endpoint: Endpoint[String] = "test1" / bindPath[String]("p1")
+    endpoint.formatString.format("hoge") === "test1/hoge"
+  }
+
+  it should "Matches the string specified when a path is generated from multiple composited Endpoints." in {
+    val endpoint1: Endpoint[String]         = "test1" / bindPath[String]("p1")
+    val endpoint2: Endpoint[Long]           = bindPath[Long]("p1") / "test2"
+    val endpoint3: Endpoint[(String, Long)] = endpoint1 ++ endpoint2
+
+    endpoint3.formatString.format("hoge", 1L) === "test1/hoge/1/test2"
   }

--- a/modules/lepus-router/src/test/scala/lepus/router/http/EndpointTest.scala
+++ b/modules/lepus-router/src/test/scala/lepus/router/http/EndpointTest.scala
@@ -61,7 +61,7 @@ class EndpointTest extends AnyFlatSpec:
 
   it should "The Endpoint string will be the same as the specified string." in {
     val endpoint1: Endpoint[String] = "test1" / bindPath[String]("p1")
-    endpoint1.formatString === "test1/%s"
+    endpoint1.toFormatPath === "test1/%s"
   }
 
   it should "If multiple Endpoints are combined, the string will be the same as the specified value." in {
@@ -69,12 +69,12 @@ class EndpointTest extends AnyFlatSpec:
     val endpoint2: Endpoint[String]           = bindPath[String]("p1") / "test2"
     val endpoint3: Endpoint[(String, String)] = endpoint1 ++ endpoint2
 
-    endpoint3.formatString === "test1/%s/%s/test2"
+    endpoint3.toFormatPath === "test1/%s/%s/test2"
   }
 
   it should "Matches the string specified when the path is generated from Endpoint." in {
     val endpoint: Endpoint[String] = "test1" / bindPath[String]("p1")
-    endpoint.formatString.format("hoge") === "test1/hoge"
+    endpoint.toFormatPath.format("hoge") === "test1/hoge"
   }
 
   it should "Matches the string specified when a path is generated from multiple composited Endpoints." in {
@@ -82,5 +82,25 @@ class EndpointTest extends AnyFlatSpec:
     val endpoint2: Endpoint[Long]           = bindPath[Long]("p1") / "test2"
     val endpoint3: Endpoint[(String, Long)] = endpoint1 ++ endpoint2
 
-    endpoint3.formatString.format("hoge", 1L) === "test1/hoge/1/test2"
+    endpoint3.toFormatPath.format("hoge", 1L) === "test1/hoge/1/test2"
+  }
+
+  it should "The Endpoint string in the Query parameter will be the same as the specified string." in {
+    val endpoint: Endpoint[(Int, Long)] = bindQuery[Int]("page") +& bindQuery[Long]("limit")
+    endpoint.toFormatQuery.format(1, 10L) === "page=1&limit=10"
+  }
+
+  it should "The Endpoint string consisting of multiple Query parameters will be the same as the specified string." in {
+    val endpoint1: Endpoint[List[String]]              = bindQuery[List[String]]("area")
+    val endpoint2: Endpoint[(Int, Long)]               = bindQuery[Int]("page") +& bindQuery[Long]("limit")
+    val endpoint3: Endpoint[(List[String], Int, Long)] = endpoint1 ++ endpoint2
+    endpoint3.toFormatQuery.format("tokyo,kanagawa", 1, 10L) === "area=tokyo,kanagawa&page=1&limit=10"
+  }
+
+  it should "The string of the Endpoint from which the Path and Query are composited will be the same as the specified value." in {
+    val endpoint1: Endpoint[String]              = "hello" / bindPath[String]("p1")
+    val endpoint2: Endpoint[(Int, Long)]         = bindQuery[Int]("page") +& bindQuery[Long]("limit")
+    val endpoint3: Endpoint[(String, Int, Long)] = endpoint1 ++ endpoint2
+
+    endpoint3.formatString.format("world", 1, 10L) === "hello/world?page=1&limit=10"
   }

--- a/modules/lepus-swagger/src/main/scala/lepus/swagger/RouterToOpenAPI.scala
+++ b/modules/lepus-swagger/src/main/scala/lepus/swagger/RouterToOpenAPI.scala
@@ -39,7 +39,7 @@ private[lepus] object RouterToOpenAPI:
 
     val component = schemaTuple.map(v => Component(v.map(x => x._1.shortName -> schemaToOpenApiSchema(x._2))))
     val endpoints = groupEndpoint.map {
-      case (endpoint, route) => endpoint.toPath -> routerToPath(endpoint, route, schemaToOpenApiSchema)
+      case (endpoint, route) => endpoint.toPath() -> routerToPath(endpoint, route, schemaToOpenApiSchema)
     }
     val tags = router.routes.toList
       .flatMap(_._2 match


### PR DESCRIPTION
## Implementation Details

-  Enable generation of string paths from Endpoint
  - Dynamic paths can be changed with scala's format method

## Pull Request Checklist

- [ ] Wrote unit and integration tests
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Code formatting by scalafmt (sbt scalafmtAll command execution)
- [ ] Add copyright headers to new files

## References

<!-- Please describe any relevant issues, PR, articles, etc. -->
